### PR TITLE
Manage duplicate declaration of user

### DIFF
--- a/manifests/slurmdbd.pp
+++ b/manifests/slurmdbd.pp
@@ -186,9 +186,9 @@ inherits slurm
     }
     # Eventually create the 'slurm'@'*' user with all rights
     unique([ $storagehost, $::hostname, $::fqdn]).each |String $host| {
-      mysql_user { "${storageuser}@${host}":
+      ensure_resource('mysql_user', "${storageuser}@${host}",{
         password_hash => mysql_password($storagepass),
-      }
+      })
       mysql_grant {  "${storageuser}@${host}/${storageloc}.*":
         privileges => ['ALL'],
         table      => "${storageloc}.*",


### PR DESCRIPTION
If dbdhost and storagehost are the same, both mysql::db and slurmdbd will attempt to create the same user. Therefore, slurmdbd should only create it if it does not already exist