### PR TITLE
avoid duplicate mysql user resources

### DIFF
--- a/manifests/slurmdbd.pp
+++ b/manifests/slurmdbd.pp
@@ -185,7 +185,7 @@ inherits slurm
       before   => File[$slurm::params::dbd_configfile],
     }
     # Eventually create the 'slurm'@'*' user with all rights
-    unique([ $storagehost, $::hostname, $::fqdn]).each |String $host| {
+    unique([ $storagehost, $::hostname, $::fqdn].delete($dbdhost)).each |String $host| {
       mysql_user { "${storageuser}@${host}":
         password_hash => mysql_password($storagepass),
       }


### PR DESCRIPTION
if any of storagehost, hostnane or  fqdn are the same as dbdhost, remove it from the list of hosts to create user for